### PR TITLE
Add diagnostic levels

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -66,27 +66,50 @@ impl Backend {
                     match &dependency.version {
                         DependencyVersion::Complete { range, version } => {
                             if !version.matches(newest_version) {
-                                Diagnostic::new_simple(
+                                Diagnostic::new(
                                     *range,
+                                    Some(DiagnosticSeverity::INFORMATION),
+                                    None,
+                                    None,
                                     format!("{}: {newest_version}", &dependency.name),
+                                    None,
+                                    None,
                                 )
                             } else {
                                 let range = Range {
                                     start: Position::new(range.start.line, 0),
                                     end: Position::new(range.start.line, 0),
                                 };
-                                Diagnostic::new_simple(range, "✓".to_string())
+                                Diagnostic::new(
+                                    range,
+                                    Some(DiagnosticSeverity::HINT),
+                                    None,
+                                    None,
+                                    "✓".to_string(),
+                                    None,
+                                    None,
+                                )
                             }
                         }
-                        DependencyVersion::Partial { range, .. } => Diagnostic::new_simple(
+                        DependencyVersion::Partial { range, .. } => Diagnostic::new(
                             *range,
+                            Some(DiagnosticSeverity::INFORMATION),
+                            None,
+                            None,
                             format!("{}: {newest_version}", &dependency.name),
+                            None,
+                            None,
                         ),
                     }
                 } else {
-                    Diagnostic::new_simple(
+                    Diagnostic::new(
                         dependency.version.range(),
+                        Some(DiagnosticSeverity::WARNING),
+                        None,
+                        None,
                         format!("{}: Unknown crate", &dependency.name),
+                        None,
+                        None,
                     )
                 }
             })

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,6 +59,9 @@ impl Backend {
         };
 
         // Produce diagnostic hints for each crate where we might be helpful.
+        let nu_sev = self.settings.needs_update_severity().await;
+        let utd_sev = self.settings.up_to_date_severity().await;
+        let ud_sev = self.settings.unknown_dep_severity().await;
         let diagnostics: Vec<_> = dependency_with_versions
             .into_iter()
             .map(|dependency| {
@@ -68,7 +71,7 @@ impl Backend {
                             if !version.matches(newest_version) {
                                 Diagnostic::new(
                                     *range,
-                                    Some(DiagnosticSeverity::INFORMATION),
+                                    Some(nu_sev),
                                     None,
                                     None,
                                     format!("{}: {newest_version}", &dependency.name),
@@ -82,7 +85,7 @@ impl Backend {
                                 };
                                 Diagnostic::new(
                                     range,
-                                    Some(DiagnosticSeverity::HINT),
+                                    Some(utd_sev),
                                     None,
                                     None,
                                     "✓".to_string(),
@@ -93,7 +96,7 @@ impl Backend {
                         }
                         DependencyVersion::Partial { range, .. } => Diagnostic::new(
                             *range,
-                            Some(DiagnosticSeverity::INFORMATION),
+                            Some(nu_sev),
                             None,
                             None,
                             format!("{}: {newest_version}", &dependency.name),
@@ -104,7 +107,7 @@ impl Backend {
                 } else {
                     Diagnostic::new(
                         dependency.version.range(),
-                        Some(DiagnosticSeverity::WARNING),
+                        Some(ud_sev),
                         None,
                         None,
                         format!("{}: Unknown crate", &dependency.name),

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use serde::Deserialize;
 use tokio::sync::RwLock;
+use tower_lsp::lsp_types::DiagnosticSeverity;
 
 #[derive(Default, Debug, Clone)]
 pub struct Settings {
@@ -19,12 +20,54 @@ impl Settings {
     pub async fn use_api(&self) -> bool {
         self.inner.read().await.lsp.use_api.unwrap_or_default()
     }
+
+    pub async fn needs_update_severity(&self) -> DiagnosticSeverity {
+        self.inner
+            .read()
+            .await
+            .lsp
+            .needs_update_severity
+            .filter(verify_severity)
+            .unwrap_or(DiagnosticSeverity::INFORMATION)
+    }
+
+    pub async fn up_to_date_severity(&self) -> DiagnosticSeverity {
+        self.inner
+            .read()
+            .await
+            .lsp
+            .up_to_date_severity
+            .filter(verify_severity)
+            .unwrap_or(DiagnosticSeverity::HINT)
+    }
+
+    pub async fn unknown_dep_severity(&self) -> DiagnosticSeverity {
+        self.inner
+            .read()
+            .await
+            .lsp
+            .unknown_dep_severity
+            .filter(verify_severity)
+            .unwrap_or(DiagnosticSeverity::WARNING)
+    }
+}
+
+// verify the config is a valid severity level
+fn verify_severity(d: &DiagnosticSeverity) -> bool {
+    *d >= DiagnosticSeverity::ERROR && *d <= DiagnosticSeverity::HINT
 }
 
 #[derive(Default, Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct LspSettings {
-    #[serde(rename = "useApi", default)]
+    #[serde(default)]
     pub use_api: Option<bool>,
+    #[serde(default)]
+    pub needs_update_severity: Option<DiagnosticSeverity>,
+    #[serde(default)]
+    pub up_to_date_severity: Option<DiagnosticSeverity>,
+    #[serde(default)]
+    pub unknown_dep_severity: Option<DiagnosticSeverity>,
 }
 
 #[derive(Default, Debug, Clone, Deserialize)]


### PR DESCRIPTION
Adds diagnostic levels to the diagnostics, and configuration for them.

This is mostly for other editors, since without a plugin to make it nice you just get a wall of warnings