### PR TITLE
Inlay hints

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -43,8 +43,7 @@ impl Backend {
         }
 
         let crate_names: Vec<&str> = dependency_with_versions
-            .clone()
-            .into_iter()
+            .iter()
             .map(|x| x.name.as_str())
             .collect();
         // Get the newest version of each crate that appears in the manifest.

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,10 @@ struct Backend {
 
 impl Backend {
     async fn calculate_diagnostics(&self, url: Url, content: &str) -> Vec<Diagnostic> {
+        if !self.settings.diagnostics().await {
+            return Vec::new();
+        }
+
         let packages = self.manifests.update_from_source(url, content).await;
 
         // Retrieve just the package names, so we can fetch the latest
@@ -287,6 +291,10 @@ impl LanguageServer for Backend {
     }
 
     async fn inlay_hint(&self, params: InlayHintParams) -> Result<Option<Vec<InlayHint>>> {
+        if !self.settings.inlay_hints().await {
+            return Ok(None);
+        }
+
         let Some(dependencies) = self.manifests.get(&params.text_document.uri).await else {
             return Ok(None);
         };

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -58,6 +58,26 @@ impl Settings {
             .filter(verify_severity)
             .unwrap_or(DiagnosticSeverity::WARNING)
     }
+
+    pub async fn up_to_date_hint(&self) -> String {
+        self.inner
+            .read()
+            .await
+            .lsp
+            .up_to_date_hint
+            .clone()
+            .unwrap_or_else(|| "✓".to_string())
+    }
+
+    pub async fn needs_update_hint(&self) -> String {
+        self.inner
+            .read()
+            .await
+            .lsp
+            .needs_update_hint
+            .clone()
+            .unwrap_or_else(|| " {}".to_string())
+    }
 }
 
 // verify the config is a valid severity level
@@ -80,6 +100,10 @@ pub struct LspSettings {
     pub up_to_date_severity: Option<DiagnosticSeverity>,
     #[serde(default)]
     pub unknown_dep_severity: Option<DiagnosticSeverity>,
+    #[serde(default)]
+    pub up_to_date_hint: Option<String>,
+    #[serde(default)]
+    pub needs_update_hint: Option<String>,
 }
 
 #[derive(Default, Debug, Clone, Deserialize)]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -21,6 +21,14 @@ impl Settings {
         self.inner.read().await.lsp.use_api.unwrap_or_default()
     }
 
+    pub async fn inlay_hints(&self) -> bool {
+        self.inner.read().await.lsp.inlay_hints.unwrap_or(true)
+    }
+
+    pub async fn diagnostics(&self) -> bool {
+        self.inner.read().await.lsp.diagnostics.unwrap_or(true)
+    }
+
     pub async fn needs_update_severity(&self) -> DiagnosticSeverity {
         self.inner
             .read()
@@ -62,6 +70,10 @@ fn verify_severity(d: &DiagnosticSeverity) -> bool {
 pub struct LspSettings {
     #[serde(default)]
     pub use_api: Option<bool>,
+    #[serde(default)]
+    pub inlay_hints: Option<bool>,
+    #[serde(default)]
+    pub diagnostics: Option<bool>,
     #[serde(default)]
     pub needs_update_severity: Option<DiagnosticSeverity>,
     #[serde(default)]


### PR DESCRIPTION
Adds inlay hints, for those editors without a fancy plugin

removed an unnecessary clone I found, for projects with lots of deps that clone would probably slow things down quite a bit

config for inlay hints and diagnostics for ppl who only want one or the other