### PR TITLE
Fix helix configuration in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,13 @@ vim.lsp.config['crates'] = {
 
 ### [Helix](https://helix-editor.com/)
 ```toml
-[language-servers.crates-lsp]
+[language-server.crates-lsp]
+command = "crates-lsp"
 except-features = ["format"]
 # config = {} # Configuration options go here
+
+[language-server.taplo]
+config = {}
 
 [[language]]
 name = "toml"


### PR DESCRIPTION
- fix typo in `[language-servers.crates-lsp]` -> `[language-server.crates-lsp]` 
- add missing `command = "crates-lsp"` field
- fix taplo `this document has been excluded` message https://github.com/helix-editor/helix/issues/3897